### PR TITLE
Unprefix methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ const actions = {
 export default factory(initialState, actions, prefix) // factory :: (Object, Object, String) -> Object
 // The above code exports an object for use in your app:
 // {
-//   usersAdd: [Function],
-//   usersSetActivity: [Function],
+//   add: [Function],
+//   setActivity: [Function],
 //   reducer: [Function]
 // }
 ```
@@ -80,11 +80,11 @@ const dogs = factory(dogsInitialState, dogsActions) // factory :: (Object, Objec
 export default compose(list, dogs, prefix) // compose :: (Function, ..., String) -> Object
 // The above code exports an object for use in your app:
 // {
-//   dogsAdd: [Function],
-//   dogsSetActivity: [Function],
-//   dogsBarking: [Function],
-//   dogsPooping: [Function],
-//   dogsRunning: [Function],
+//   add: [Function],
+//   setActivity: [Function],
+//   barking: [Function],
+//   pooping: [Function],
+//   running: [Function],
 //   reducer: [Function]
 // }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-factory",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Composable, curried factory for creating Redux reducers and actions",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-factory",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Composable, curried factory for creating Redux reducers and actions",
   "main": "index.js",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,19 +16,19 @@ var camelCased  = function(x) {
 }
 exports.camelCased = camelCased
 
-var methodized = function(name) {
-  var obj = {}
-  obj[name] = function(x) { return { type: R.compose(R.toUpper,underscored)(name), payload: x } }
-  return obj
-}
-exports.methodized = methodized
-
 var constPrefixedWith = function(x) {
   return R.compose(R.toUpper, underscored, prefixedWith(x))
 }
 exports.constPrefixedWith = constPrefixedWith
 
+var methodized = R.curry(function(prefix, name) {
+  var obj = {}
+  obj[name] = function(x) { return { type: R.compose(R.toUpper,underscored, constPrefixedWith(prefix))(name), payload: x } }
+  return obj
+})
+exports.methodized = methodized
+
 var methodObject = R.curry(function(prefix, names) {
-  return R.compose(R.mergeAll, R.map(R.compose(methodized, camelCased, constPrefixedWith(prefix))))(names)
+  return R.compose(R.mergeAll, R.map(R.compose(methodized(prefix), camelCased)))(names)
 })
 exports.methodObject = methodObject

--- a/test/compose.test.js
+++ b/test/compose.test.js
@@ -27,8 +27,8 @@ describe('compose', function() {
   it('returns combined reduxFactories', function() {
     var actual = compose(list, other, 'user')
     var wanted = [
-      'userAdd',
-      'userChangeName',
+      'add',
+      'changeName',
       'reducer'
     ]
     expect(actual).has.keys(wanted)
@@ -36,8 +36,8 @@ describe('compose', function() {
   it('returns curried function if string prefix is not passed', function() {
     var actual = compose(list, other)('user')
     var wanted = [
-      'userAdd',
-      'userChangeName',
+      'add',
+      'changeName',
       'reducer'
     ]
     expect(actual).has.keys(wanted)
@@ -46,10 +46,10 @@ describe('compose', function() {
     var first = compose(list, other)
     var actual = compose(first, yetAnother, 'user')
     var wanted = [
-      'userAdd',
-      'userChangeName',
+      'add',
+      'changeName',
       'reducer',
-      'userSetAge'
+      'setAge'
     ]
     expect(actual).has.keys(wanted)
   })
@@ -61,25 +61,25 @@ describe('compose', function() {
   })
   it('conflicting keys are merged right to left', function() {
     var combined = compose(list, other, 'user')
-    var actual = combined.reducer(undefined, combined.userChangeName('Rob'))
+    var actual = combined.reducer(undefined, combined.changeName('Rob'))
     var wanted = {name: 'Rob', list: []}
     expect(actual).eql(wanted)
   })
   it('handles actions from first factory', function() {
     var combined = compose(list, other, 'user')
-    var actual = combined.reducer({list: [], name: ''}, combined.userAdd({name: 'Rob'}))
+    var actual = combined.reducer({list: [], name: ''}, combined.add({name: 'Rob'}))
     var wanted = {list: [{name: 'Rob'}], name: ''}
     expect(actual).eql(wanted)
   })
   it('handles actions from second factory', function() {
     var combined = compose(list, other, 'user')
-    var actual = combined.reducer({list: [], name: ''}, combined.userChangeName('Rob'))
+    var actual = combined.reducer({list: [], name: ''}, combined.changeName('Rob'))
     var wanted = {list: [], name: 'Rob'}
     expect(actual).eql(wanted)
   })
   it('handles actions from third factory', function() {
     var combined = compose(list, other, yetAnother, 'user')
-    var actual = combined.reducer({list: [], name: 'Rob'}, combined.userSetAge(31))
+    var actual = combined.reducer({list: [], name: 'Rob'}, combined.setAge(31))
     var wanted = {list: [], name: 'Rob', age: 31}
     expect(actual).eql(wanted)
   })

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -30,7 +30,7 @@ describe('reduxFactory :: (Object, [Object], String) -> Object', function() {
       expect(actual).eql(wanted)
     })
     it('handles action', function() {
-      var actual = testReducer.reducer({list: ['Tim']}, testReducer.userListAdd('Joe'))
+      var actual = testReducer.reducer({list: ['Tim']}, testReducer.listAdd('Joe'))
       var wanted = {list: ['Tim', 'Joe']}
       expect(actual).eql(wanted)
     })

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -31,7 +31,7 @@ describe('helpers:', function() {
   describe('methodized()', function() {
     it('exists', function() { expect(helpers.methodized).to.exist })
     it('returns actionCreator method', function() {
-      var actual = helpers.methodized('userTest').userTest('tim')
+      var actual = helpers.methodized('user', 'test').test('tim')
       var wanted = {type: 'USER_TEST', payload: 'tim'}
       expect(actual).eql(wanted)
     })
@@ -54,7 +54,7 @@ describe('helpers:', function() {
     })
     it('returns object with matching methods', function() {
       var actual = helpers.methodObject('user')(['rob', 'tim'])
-      var wanted = [ 'userRob', 'userTim' ]
+      var wanted = [ 'rob', 'tim' ]
       expect(actual).have.keys(wanted)
     })
   })


### PR DESCRIPTION
- returns object with unprefixed methods since they were redundant and made namespacing within a usage context clumsy
