### PR TITLE
Version 3.0.0 - Remove automatic state merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ const initialState = { // required by Redux
 }
 
 const actions = {
-  add: (payload, state) => {list: [...state, payload]},
-  setActivity: payload => ({activity: payload})
+  add: (state, payload) => Object.assign({}, state, {list: [...state, payload]}),
+  setActivity: (state, payload) => Object.assign({}, state, {activity: payload})
 }
 
 export default factory(initialState, actions, prefix) // factory :: (Object, Object, String) -> Object
@@ -55,8 +55,8 @@ const listInitialState = { // required by Redux
 }
 
 const listActions = {
-  add: (payload, state) => {list: [...state, payload]},
-  setActivity: payload => ({activity: payload})
+  add: (state, payload) => Object.assign({}, state, {list: [...state, payload]}),
+  setActivity: (state, payload) => Object.assign({}, state, {activity: payload})
 }
 
 const list = factory(listInitialState, listActions) // factory :: (Object, Object) -> Function
@@ -70,9 +70,9 @@ const dogsInitialState = {
 }
 
 const dogsActions = {
-  barking: x => ({ barking: x }),
-  pooping: x => ({ pooping: x }),
-  running: x => ({ running: x })
+  barking: (x, y) => Object.assign({}, x, { barking: y }),
+  pooping: (x, y) => Object.assign({}, x, { pooping: y }),
+  running: (x, y) => Object.assign({}, x, { running: y })
 }
 
 const dogs = factory(dogsInitialState, dogsActions) // factory :: (Object, Object) -> Function
@@ -100,11 +100,21 @@ export default compose(list, dogs, prefix) // compose :: (Function, ..., String)
 - Curried: `true` (all arguments may be partially applied)
 - Parameters:
   - **initialState**: object required by redux
-  - **actions**: object of action methods (e.g. `{ actionName: x => ({name: x}) }`)
-    - `payload` is the first parameter since it is always used
-    - `state` is the second parameter as it is often unused
+  - **actions**: object of action methods (e.g. `{ actionName: (state, payload) => Object.assign({}, state, {name: payload}) }`)
+    - `state` current state
+    - `payload` action payload
   - **prefix**: string used to create unique actions and reducers
-- Returns: object with prefixed action method(s) and a reducer method
+- Returns `Object` with action method(s) and a reducer method to export and use in your app:
+```js
+{
+  add: [Function],
+  setActivity: [Function],
+  barking: [Function],
+  pooping: [Function],
+  running: [Function],
+  reducer: [Function]
+}
+```
 
 ### Compose
 - Signature: `(Function: unprefixed Factory || unprefixed Compose, ..., String: prefix) -> Object`
@@ -112,6 +122,17 @@ export default compose(list, dogs, prefix) // compose :: (Function, ..., String)
 - Parameters:
   - **All but last**: unprefixed Factory or Compose functions
   - **Last**: prefix string used to create unique actions and reducers
+
+## Tips
+1. Use a helper to merge old and new state (e.g. Ramda's [merge](http://ramdajs.com/0.21.0/docs/#merge)). Originally, `redux-factory` automatically merged old/new state, but this proved unintuitive.
+
+```js
+import { merge } from 'ramda'
+// Much better!
+const actions = {
+  myAction: (x, y) => merge(x, {name: y})
+}
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-factory",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Composable, curried factory for creating Redux reducers and actions",
   "main": "index.js",
   "scripts": {

--- a/src/reducerCreator.js
+++ b/src/reducerCreator.js
@@ -12,7 +12,7 @@ module.exports = R.curry(function(initialState, actionDefinitions, prefix) {
           var keyType = toConst(key)
           return [
             function() { return keyType == action.type },
-            function() { return R.merge(state, actionDef[1](action.payload, state || initialState)) }
+            function() { return actionDef[1](state || initialState, action.payload) }
           ]
         },
         R.toPairs(actionDefinitions)))

--- a/test/compose.test.js
+++ b/test/compose.test.js
@@ -1,25 +1,26 @@
 var factory = require('factory')
 var compose = require('compose')
+var R = require('ramda')
 
 var list = factory(
   { list: [], name: 'Rob' },
   {
-    add:     function(x, y) { return {list: y.list.concat(x)} },
-    changeName: function(x) { return {name: 'Your name is ' + x} }
+    add:        function(x, y) { return R.merge(x, {list: x.list.concat(y)}) },
+    changeName: function(x, y) { return R.merge(x, {name: 'Your name is ' + y}) }
   }
 )
 
 var other = factory(
   { name: '' },
   {
-    changeName: function(x) { return {name: x} }
+    changeName: function(x, y) { return R.merge(x, {name: y}) }
   }
 )
 
 var yetAnother = factory(
   { age: 21 },
   {
-    setAge: function(x) { return {age: x} }
+    setAge: function(x, y) { return R.merge(x, {age: y}) }
   }
 )
 

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -1,4 +1,5 @@
 var reducer = require('factory')
+var R = require('ramda')
 
 var testReducer = reducer(
   {
@@ -7,8 +8,8 @@ var testReducer = reducer(
     name: 'user'
   },
   {
-    listAdd: function(x,y) { return {list: y.list.concat(x)} },
-    nameEdit: function(x) { return {name: x} }
+    listAdd:  function(x,y) { return R.merge(x, {list: x.list.concat(y)}) },
+    nameEdit: function(x,y) { return R.merge(x, {name: y}) }
   },
   'USER'
 )
@@ -34,10 +35,19 @@ describe('reduxFactory :: (Object, [Object], String) -> Object', function() {
       var wanted = {list: ['Tim', 'Joe']}
       expect(actual).eql(wanted)
     })
-    it('handles bad action action', function() {
+    it('handles bad action', function() {
       var actual = testReducer.reducer({list: ['Tim']}, {type: 'NOT', payload: 'Joe'})
       var wanted = {list: ['Tim']}
       expect(actual).eql(wanted)
     })
+    it('can take any form of state (Array, Object, String)', function() {
+      var plainArray = reducer([], { add:  function(x,y) { return [].concat(x, y) } }, 'array')
+      var plainString = reducer('init', { add:  function(x,y) { return y } }, 'string')
+      expect(plainArray.reducer(undefined, plainArray.add('hi'))).eql(['hi'])
+      expect(plainArray.reducer(undefined, {type: 'NONE', payload: ''})).eql([])
+      expect(plainString.reducer(undefined, plainString.add('hi'))).eql('hi')
+      expect(plainString.reducer(undefined, {type: 'NONE', payload: ''})).eql('init')
+    })
   })
+
 })

--- a/test/reducerCreator.test.js
+++ b/test/reducerCreator.test.js
@@ -1,4 +1,5 @@
 var reducerCreator = require('reducerCreator')
+var R = require('ramda')
 
 describe('reducerCreator :: (Object, Array, String) -> (Object, Object) -> Object', function() {
 
@@ -13,7 +14,7 @@ describe('reducerCreator :: (Object, Array, String) -> (Object, Object) -> Objec
 
   it('reducer handles state and action',
     function() {
-      var reducer = reducerCreator({name: 'rob'}, { actionType: function(x){ return {name: x} } }, 'prefix')
+      var reducer = reducerCreator({name: 'rob'}, { actionType: function(x, y){ return R.merge(x, {name: y}) } }, 'prefix')
       var actual = reducer(undefined, {type: 'PREFIX_ACTION_TYPE', payload: 'joe'})
       var wanted = {name: 'joe'}
       expect(actual).eql(wanted)


### PR DESCRIPTION
To avoid confusion, current state is no longer automatically merged with the product of an action. This allows you to shape a store in whatever way you see fit. Also, action callback state and payload parameters have been switched to better align with typical argument order.

Changes:
- Remove state auto-merge
- Reverse action callback parameters (e.g. `(payload, state) -> (state, payload)`)
- Update tests
- Update documentation
- Update version to 3.0.0 - these are breaking changes
